### PR TITLE
fix: replace terser with esbuild for Vercel compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(() => {
       },
       build: {
         target: 'es2020',
-        minify: 'terser' as const,
+        minify: 'esbuild',
         rollupOptions: {
           output: {
             manualChunks: {


### PR DESCRIPTION
- Switch from terser to esbuild minification
- Remove terser dependency to avoid build errors
- esbuild is faster and more reliable for Vercel deployments
- Fixes 'terser not found' error during build process
