### PR TITLE
feat: Add BackToTop component with scroll-to-top functionality and tests

### DIFF
--- a/app.tsx
+++ b/app.tsx
@@ -12,6 +12,7 @@ import JobBoard from './components/JobBoard';
 import Navigation from './components/Navigation';
 import Footer from './components/Footer';
 import ErrorBoundary from './components/ErrorBoundary';
+import BackToTop from './components/BackToTop';
 
 function App() {
   const location = useLocation();
@@ -58,6 +59,7 @@ function App() {
           </Routes>
         </main>
         <Footer />
+        <BackToTop />
       </div>
     </ErrorBoundary>
   );

--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * MIT
+ * Collective AI Tools (https://collectiveai.tools)
+ */
+
+import React, { useState, useEffect } from 'react';
+import { ChevronUpIcon } from 'lucide-react';
+import { cn } from '../lib/utils';
+
+interface BackToTopProps {
+  showAfter?: number;
+  className?: string;
+}
+
+const BackToTop: React.FC<BackToTopProps> = ({ 
+  showAfter = 300, 
+  className 
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.pageYOffset > showAfter) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', toggleVisibility);
+
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility);
+    };
+  }, [showAfter]);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className={cn(
+        "fixed bottom-8 right-8 z-50",
+        "h-12 w-12 rounded-full",
+        "bg-primary text-primary-foreground",
+        "hover:bg-primary/90",
+        "shadow-lg hover:shadow-xl",
+        "transition-all duration-300 ease-in-out",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "transform hover:scale-110",
+        "border border-border/20",
+        className
+      )}
+      aria-label="Back to top"
+      title="Back to top"
+    >
+      <ChevronUpIcon className="h-5 w-5 mx-auto" />
+    </button>
+  );
+};
+
+export default BackToTop;

--- a/components/__tests__/BackToTop.test.tsx
+++ b/components/__tests__/BackToTop.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * MIT
+ * Collective AI Tools (https://collectiveai.tools)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BackToTop from '../BackToTop';
+
+// Mock window.scrollTo
+const mockScrollTo = vi.fn();
+Object.defineProperty(window, 'scrollTo', {
+  value: mockScrollTo,
+  writable: true,
+});
+
+describe('BackToTop', () => {
+  beforeEach(() => {
+    mockScrollTo.mockClear();
+    // Reset scroll position
+    Object.defineProperty(window, 'pageYOffset', {
+      value: 0,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should not render when page is at top', () => {
+    render(<BackToTop />);
+    const button = screen.queryByRole('button', { name: /back to top/i });
+    expect(button).not.toBeInTheDocument();
+  });
+
+  it('should render when scrolled past threshold', () => {
+    render(<BackToTop showAfter={300} />);
+    
+    // Simulate scroll past threshold
+    Object.defineProperty(window, 'pageYOffset', {
+      value: 400,
+      writable: true,
+    });
+    
+    fireEvent.scroll(window);
+    
+    const button = screen.getByRole('button', { name: /back to top/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should scroll to top when clicked', () => {
+    render(<BackToTop showAfter={100} />);
+    
+    // Simulate scroll past threshold
+    Object.defineProperty(window, 'pageYOffset', {
+      value: 200,
+      writable: true,
+    });
+    
+    fireEvent.scroll(window);
+    
+    const button = screen.getByRole('button', { name: /back to top/i });
+    fireEvent.click(button);
+    
+    expect(mockScrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth',
+    });
+  });
+
+  it('should apply custom className', () => {
+    render(<BackToTop showAfter={100} className="custom-class" />);
+    
+    // Simulate scroll past threshold
+    Object.defineProperty(window, 'pageYOffset', {
+      value: 200,
+      writable: true,
+    });
+    
+    fireEvent.scroll(window);
+    
+    const button = screen.getByRole('button', { name: /back to top/i });
+    expect(button).toHaveClass('custom-class');
+  });
+
+  it('should have proper accessibility attributes', () => {
+    render(<BackToTop showAfter={100} />);
+    
+    // Simulate scroll past threshold
+    Object.defineProperty(window, 'pageYOffset', {
+      value: 200,
+      writable: true,
+    });
+    
+    fireEvent.scroll(window);
+    
+    const button = screen.getByRole('button', { name: /back to top/i });
+    expect(button).toHaveAttribute('aria-label', 'Back to top');
+    expect(button).toHaveAttribute('title', 'Back to top');
+  });
+});


### PR DESCRIPTION
This pull request introduces a new "Back to Top" button component to the application, enhancing user experience by allowing users to quickly return to the top of the page after scrolling. The button appears after the user scrolls past a specified threshold and includes smooth scrolling, accessibility features, and customizable styling. Comprehensive unit tests are also added to ensure correct behavior and accessibility.

<img width="1916" height="928" alt="image" src="https://github.com/user-attachments/assets/362b0e26-6fcb-49e3-9b3d-98062165396f" />


**Feature Addition:**

* Added a new `BackToTop` component in `components/BackToTop.tsx` that displays a floating button when the user scrolls down the page, allowing them to smoothly scroll back to the top. The component supports a configurable scroll threshold and custom class names, and includes accessibility attributes.
* Integrated the `BackToTop` component into the main application layout in `app.tsx`, so it appears on all pages. [[1]](diffhunk://#diff-74eeb7971a609330e96cecf65ba1960a5712cf34919f110d77ab6137746c82e9R15) [[2]](diffhunk://#diff-74eeb7971a609330e96cecf65ba1960a5712cf34919f110d77ab6137746c82e9R62)

**Testing:**

* Added a test suite in `components/__tests__/BackToTop.test.tsx` to verify the component's rendering logic, click behavior, custom class support, and accessibility attributes.

#179 

I’d appreciate it if you could kindly add the hacktoberfest topic or label to this repository. This helps ensure the PR is counted toward the event.